### PR TITLE
Allow buttons to be links

### DIFF
--- a/.changeset/fifty-months-breathe.md
+++ b/.changeset/fifty-months-breathe.md
@@ -1,0 +1,5 @@
+---
+'@terrazzo/tiles': patch
+---
+
+Allow buttons to be links

--- a/docs/src/routes/components/button/+page.svelte
+++ b/docs/src/routes/components/button/+page.svelte
@@ -36,7 +36,7 @@
 					<tr>
 						<th scope="row">variant="{variant}"</th>
 						{#each sizes as size}
-							<td><Button {size} {variant}><span class="button-name">{variant} ({size})</span></Button></td>
+							<td><Button {size} {variant} href="#"><span class="button-name">{variant} ({size})</span></Button></td>
 						{/each}
 					</tr>
 				{/each}

--- a/src/button.svelte
+++ b/src/button.svelte
@@ -8,9 +8,15 @@
 	export let size: 's' | 'm' | 'l' = 'm';
 	/** button type */
 	export let type: 'button' | 'submit' = 'button';
+	/** href (only use if button is a link) */
+	export let href: string | undefined = undefined;
 </script>
 
-<button {...omit($$props, ['color', 'size', 'type', 'variant'])} class="button" {type} data-variant={variant} data-size={size}><slot /></button>
+{#if href}
+	<a {...omit($$props, ['color', 'href', 'size', 'type', 'variant'])} {href} class="button" {type} data-variant={variant} data-size={size}><slot /></a>
+{:else}
+	<button {...omit($$props, ['color', 'size', 'type', 'variant'])} class="button" {type} data-variant={variant} data-size={size}><slot /></button>
+{/if}
 
 <style lang="scss">
 	@use '../tokens' as *;
@@ -43,6 +49,7 @@
 		padding-left: var(--padding);
 		padding-right: var(--padding);
 		padding-top: 0;
+		text-decoration: none;
 		white-space: nowrap;
 
 		// variants


### PR DESCRIPTION
## Changes

Allow `href` on buttons.

Yes, it’s pedantically incorrect. But it’s a heck of a lot easier than having a separate `AnchorButton` component or something dumb like that.

## How to Review



## Checklist

- [ ] Tests updated
